### PR TITLE
Update hapi fhir to 5.4.1

### DIFF
--- a/dot-base.dockerapp/docker-compose.yml
+++ b/dot-base.dockerapp/docker-compose.yml
@@ -156,12 +156,11 @@ services:
     environment:
       PROXY_ADDRESS: ${PROXY_ADDRESS}
       PROXY_PORT: ${PROXY_PORT}
-
-      HAPI_SERVER_ADDRESS: "https://${HOSTNAME}/api/fhir/"
-      HAPI_DATASOURCE_URL: "jdbc:postgresql://fhir-db:5432/hapi_r4"
-      HAPI_DATASOURCE_USERNAME: ${FHIR_DB_USER}
-      HAPI_DATASOURCE_PASSWORD: ${FHIR_DB_PASSWORD}
-      HAPI_SSO_REALM_ADDRESS: "http://keycloak:8080/auth/realms/dotbase"
+      HAPI_FHIR_SERVER_ADDRESS: "https://${HOSTNAME}/api/fhir/"
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://fhir-db:5432/hapi_r4"
+      SPRING_DATASOURCE_USERNAME: ${FHIR_DB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${FHIR_DB_PASSWORD}
+      IDENTITY_PROVIDER_REALM: "http://keycloak:8080/auth/realms/dotbase"
 
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT}
       SENTRY_DSN: ${FHIR_SERVER_SENTRY_DSN}

--- a/dot-base.dockerapp/docker-compose.yml
+++ b/dot-base.dockerapp/docker-compose.yml
@@ -152,7 +152,7 @@ services:
         - "traefik.http.services.frontend.loadbalancer.server.port=80"
 
   fhir-server:
-    image: ghcr.io/dot-base/fhir-server:7.0.0
+    image: ghcr.io/dot-base/fhir-server:8.0.0
     environment:
       PROXY_ADDRESS: ${PROXY_ADDRESS}
       PROXY_PORT: ${PROXY_PORT}


### PR DESCRIPTION
### 🚀 Feature Description
This PR introduces changes in variable names due to updating the fhir-server to use hapi-fhir 5.4.1

### 🧰 Technical Solution
- [x] update docker-compose.yml

