### PR TITLE
v0.2.2

### DIFF
--- a/dot-base.dockerapp/docker-compose.yml
+++ b/dot-base.dockerapp/docker-compose.yml
@@ -152,7 +152,7 @@ services:
         - "traefik.http.services.frontend.loadbalancer.server.port=80"
 
   fhir-server:
-    image: ghcr.io/dot-base/fhir-server:8.0.1
+    image: ghcr.io/dot-base/fhir-server:8.0.2
     environment:
       PROXY_ADDRESS: ${PROXY_ADDRESS}
       PROXY_PORT: ${PROXY_PORT}


### PR DESCRIPTION
### ⚠️ Service patches
- Update patch version of fhir-server to v8.0.2
